### PR TITLE
Advanced Filters

### DIFF
--- a/src/components/advanced-filter/AdvancedFilter.spec.js
+++ b/src/components/advanced-filter/AdvancedFilter.spec.js
@@ -1,0 +1,163 @@
+// This file contains tests for the Advanced Filters that were
+// designed for the Alert Rule Create or Update view, so the
+// context comes from that view. They should be completed and
+// made generic, but the logic is OK.
+
+describe('Update Advanced Filters', () => {
+  it('Should be able to open a rule with a null filter', () => {
+    cy.fixture('alert-rules').then(({ coldChain }) => {
+      coldChain.body.filters = null;
+      cy.fixture('tenant').then(({ jeodus }) => {
+        cy.request({
+          method: 'PUT',
+          url: `${backend}/tenant-${jeodus.tenant.group}-${jeodus.tenant.name}/${ALERT_RULES_COLLECTION}/${coldChain._id}/_replace`,
+          body: coldChain.body,
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('user_token')}`
+          }
+        });
+      });
+      cy.visit(`/admin/alerts/update/${coldChain._id}`);
+      cy.get('[data-cy="AdvancedFilter-attributeSelect--0.0"]').should(
+        'be.enabled'
+      );
+      cy.get('[data-cy="AdvancedFilter-operator--0.0"]').should('be.disabled');
+    });
+  });
+
+  it('Should add an OR-condition to an existing filter', () => {
+    cy.fixture('alert-rules').then(({ coldChain }) => {
+      cy.visit(`/admin/alerts/update/${coldChain._id}`);
+      cy.get('[data-cy=AdvancedFilter-OrBtn--0]').click();
+      const newPredicate = {
+        attribute: 'reference',
+        operator: 'matches exactly',
+        value: 'Guybrush'
+      };
+      cy.get('[data-cy="AdvancedFilter-attributeSelect--1.0"]').select(
+        newPredicate.attribute
+      );
+      cy.get('[data-cy="AdvancedFilter-operator--1.0"]').select(
+        newPredicate.operator
+      );
+      cy.get('[data-cy="AdvancedFilter-valueInput--1.0"]').type(
+        `{selectall}${newPredicate.value}`
+      );
+
+      cy.get('[data-cy=Submit-btn]').click();
+      cy.url().should('not.contain', coldChain._id);
+
+      cy.fixture('tenant').then(({ jeodus }) => {
+        cy.request({
+          method: 'GET',
+          url: `${backend}/tenant-${jeodus.tenant.group}-${jeodus.tenant.name}/${ALERT_RULES_COLLECTION}/${coldChain._id}`,
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('user_token')}`
+          }
+        }).then(response => {
+          coldChain.body.filters.or.push({
+            and: [
+              {
+                equals: {
+                  [newPredicate.attribute]: newPredicate.value
+                }
+              }
+            ]
+          });
+          delete response.body.result._source._kuzzle_info;
+          expect(response.body.result._source).to.deep.equal(coldChain.body);
+        });
+      });
+    });
+  });
+
+  it('Should delete an OR-condition from an existing filter', () => {
+    cy.fixture('alert-rules').then(({ coldChain }) => {
+      // Update the existing alert with a new clause, so that we can
+      // delete it in the test
+      const enrichedContent = cloneDeep(coldChain.body);
+      enrichedContent.filters.or.push({
+        and: [
+          {
+            equals: {
+              reference: 'Guybrush'
+            }
+          }
+        ]
+      });
+
+      cy.fixture('tenant').then(({ jeodus }) => {
+        cy.request({
+          method: 'PUT',
+          url: `${backend}/tenant-${jeodus.tenant.group}-${jeodus.tenant.name}/${ALERT_RULES_COLLECTION}/${coldChain._id}/_update`,
+          body: enrichedContent,
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('user_token')}`
+          }
+        });
+        cy.visit(`/admin/alerts/update/${coldChain._id}`);
+        cy.get('[data-cy="AdvancedFilter-removeAndBtn--1.0"]').click();
+
+        cy.get('[data-cy=Submit-btn]').click();
+        cy.url().should('not.contain', coldChain._id);
+
+        cy.request({
+          method: 'GET',
+          url: `${backend}/tenant-${jeodus.tenant.group}-${jeodus.tenant.name}/${ALERT_RULES_COLLECTION}/${coldChain._id}`,
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('user_token')}`
+          }
+        }).then(response => {
+          delete response.body.result._source._kuzzle_info;
+          expect(response.body.result._source).to.deep.equal(coldChain.body);
+        });
+      });
+    });
+  });
+
+  it('Adding an empty OR-condition to an existing filter should not alter it', () => {
+    cy.fixture('alert-rules').then(({ coldChain }) => {
+      cy.visit(`/admin/alerts/update/${coldChain._id}`);
+      cy.get('[data-cy=AdvancedFilter-OrBtn--0]').click();
+
+      cy.get('[data-cy=Submit-btn]').click();
+      cy.url().should('not.contain', coldChain._id);
+
+      cy.fixture('tenant').then(({ jeodus }) => {
+        cy.request({
+          method: 'GET',
+          url: `${backend}/tenant-${jeodus.tenant.group}-${jeodus.tenant.name}/${ALERT_RULES_COLLECTION}/${coldChain._id}`,
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('user_token')}`
+          }
+        }).then(response => {
+          const updatedRule = response.body.result._source;
+          expect(updatedRule.filters).to.deep.equal(coldChain.body.filters);
+        });
+      });
+    });
+  });
+
+  it('Should reset a filter by deleting the only predicate', () => {
+    cy.fixture('alert-rules').then(({ coldChain }) => {
+      cy.visit(`/admin/alerts/update/${coldChain._id}`);
+
+      cy.get('[data-cy="AdvancedFilter-removeAndBtn--0.0"]').click();
+
+      cy.get('[data-cy=Submit-btn]').click();
+      cy.url().should('not.contain', coldChain._id);
+
+      cy.fixture('tenant').then(({ jeodus }) => {
+        cy.request({
+          method: 'GET',
+          url: `${backend}/tenant-${jeodus.tenant.group}-${jeodus.tenant.name}/${ALERT_RULES_COLLECTION}/${coldChain._id}`,
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem('user_token')}`
+          }
+        }).then(response => {
+          expect(response.body.result._source.filters).to.eql(null);
+        });
+      });
+    });
+  });
+});

--- a/src/components/advanced-filter/AdvancedFilter.vue
+++ b/src/components/advanced-filter/AdvancedFilter.vue
@@ -1,0 +1,334 @@
+<template>
+  <div class="AdvancedFilter" data-cy="AdvancedFilter">
+    <div class="AdvancedFilter-predicates">
+      <div class="AdvancedFilter-predicate">
+        <div
+          v-for="(orBlock, orIndex) in filter"
+          :key="`orBlock-${orIndex}`"
+          class="AdvancedFilter-orBlock"
+        >
+          <b-card body-bg-variant="light">
+            <template v-if="orIndex === filter.length - 1" v-slot:footer>
+              <b-button
+                variant="outline-secondary"
+                :data-cy="`AdvancedFilter-OrBtn--${orIndex}`"
+                @click="addOrCondition"
+              >
+                <i class="fa fa-plus left mr-2" />OR
+              </b-button>
+            </template>
+            <b-row
+              align-v="center"
+              align-h="center"
+              class="mt-1"
+              v-for="(andBlock, andIndex) in orBlock"
+              no-gutters
+              :key="`andBlock-${andIndex}`"
+            >
+              <b-col xl="11">
+                <b-row align-v="center" align-h="center" no-gutters>
+                  <b-col cols="11" class="mt-1">
+                    <b-row align-v="center" align-h="center">
+                      <b-col class="text-center mb-1 px-0" xl="1">
+                        <span
+                          v-if="andIndex !== 0"
+                          class="text-secondary font-weight-bold"
+                        >
+                          AND
+                        </span>
+                      </b-col>
+                      <b-col xl="4" class="mb-1">
+                        <b-row align-v="center" align-h="center">
+                          <b-col>
+                            <b-form-select
+                              placeholder="Attribute"
+                              v-model="andBlock.attribute"
+                              :data-cy="
+                                `AdvancedFilter-attributeSelect--${orIndex}.${andIndex}`
+                              "
+                              :options="selectAttributesValues"
+                              @change="onAttributeChange(orIndex, andIndex)"
+                            >
+                              <template v-slot:first>
+                                <b-form-select-option :value="null" disabled
+                                  >Field</b-form-select-option
+                                >
+                              </template>
+                            </b-form-select>
+                          </b-col>
+                        </b-row>
+                      </b-col>
+                      <b-col xl="3" class="mb-1">
+                        <b-form-select
+                          :disabled="!andBlock || !andBlock.attribute"
+                          v-model="andBlock.operator"
+                          :data-cy="
+                            `AdvancedFilter-operator--${orIndex}.${andIndex}`
+                          "
+                          :options="
+                            andBlock
+                              ? getOperatorsForAttribute(orIndex, andIndex)
+                              : []
+                          "
+                          @change="$emit('input', filter)"
+                        >
+                          <template v-slot:first>
+                            <b-form-select-option :value="null" disabled
+                              >Operator</b-form-select-option
+                            >
+                          </template>
+                        </b-form-select>
+                      </b-col>
+                      <b-col xl="4" class="mb-1">
+                        <!-- TODO Complete the operator UIs -->
+                        <template
+                          v-if="
+                            [
+                              'exact_match',
+                              'fuzzy_match',
+                              'regexp_match'
+                            ].includes(andBlock.operator)
+                          "
+                        >
+                          <b-form-input
+                            class="AdvancedFilter--value validate"
+                            placeholder="Value"
+                            type="text"
+                            :data-cy="
+                              `AdvancedFilter-valueInput--${orIndex}.${andIndex}`
+                            "
+                            v-model="andBlock.value"
+                            @input="$emit('input', filter)"
+                          />
+                        </template>
+                        <template
+                          v-if="
+                            ['range', 'date_range_ts'].includes(
+                              andBlock.operator
+                            )
+                          "
+                        >
+                          <!-- TODO should support both gte and gt -->
+                          <b-form-input
+                            v-model="andBlock.value.gt"
+                            placeholder="Value 1"
+                            type="text"
+                            class="AdvancedFilter--gtValue validate mb-1"
+                            :data-cy="`AdvancedFilter-operator-Range-Value1`"
+                            @input="$emit('input', filter)"
+                          />
+                          <!-- TODO should support both lte and lt -->
+                          <b-form-input
+                            v-model="andBlock.value.lt"
+                            placeholder="Value 2"
+                            type="text"
+                            class="AdvancedFilter--ltValue validate mt-1"
+                            :data-cy="`AdvancedFilter-operator-Range-Value2`"
+                            @input="$emit('input', filter)"
+                          />
+                        </template>
+                        <template
+                          v-if="
+                            [
+                              'date_range',
+                              'is_in',
+                              'geoBoundingBox',
+                              'geoDistanceRange',
+                              'geoDistance',
+                              'geoPolygon'
+                            ].includes(andBlock.operator)
+                          "
+                        >
+                          Operator not yet supported
+                        </template>
+                      </b-col>
+                    </b-row>
+                  </b-col>
+                  <b-col sm="1" class="text-center">
+                    <!-- TODO enable to delete the first condition if there are more than zero -->
+                    <b-button
+                      v-if="filter.length > 0 || orBlock.length > 0"
+                      :data-cy="
+                        `AdvancedFilter-removeAndBtn--${orIndex}.${andIndex}`
+                      "
+                      @click="removeAndCondition(orIndex, andIndex)"
+                    >
+                      <i class="fa fa-times pointer" />
+                    </b-button>
+                  </b-col>
+                </b-row>
+              </b-col>
+              <b-col xl="1">
+                <b-row align-v="center" align-h="center">
+                  <b-button
+                    v-if="andIndex === orBlock.length - 1"
+                    variant="outline-secondary"
+                    :data-cy="`AdvancedFilter-andBtn--${orIndex}.${andIndex}`"
+                    @click="addAndCondition(orIndex)"
+                  >
+                    <i class="fa fa-plus left mr-1" />AND
+                  </b-button>
+                </b-row>
+              </b-col>
+            </b-row>
+          </b-card>
+
+          <b-row v-if="orIndex < filter.length - 1">
+            <b-col class="pr-0 mr-0" md="5"><hr /></b-col>
+            <b-col
+              md="2"
+              class="pr-0 mr-0 pl-0 ml-0 mt-2 text-center text-secondary"
+            >
+              <b>OR</b>
+            </b-col>
+            <b-col class="pl-0 ml-0" md="5"><hr /></b-col>
+          </b-row>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import {
+  BCard,
+  BRow,
+  BCol,
+  BButton,
+  BFormInput,
+  BFormSelect,
+  BFormSelectOption
+} from 'bootstrap-vue';
+import cloneDeep from 'lodash/cloneDeep';
+import { getOperatorsByFieldType, emptyAdvancedFilter } from '@/services/FilterUtils';
+
+export default {
+  name: 'AdvancedFilter',
+  components: {
+    BCard,
+    BRow,
+    BCol,
+    BButton,
+    BFormInput,
+    BFormSelect,
+    BFormSelectOption
+  },
+  props: {
+    attributes: {
+      type: Object,
+      required: true
+    },
+    value: {
+      type: Array,
+      default: null
+    },
+    lang: {
+      type: String,
+      default: 'koncorde',
+      validator: function(value) {
+        return value === 'koncorde' || value === 'es';
+      }
+    }
+  },
+  data() {
+    return {
+      filter: [[{ attribute: null, operator: null, value: null }]]
+    };
+  },
+  computed: {
+    selectAttributesValues() {
+      return Object.keys(this.attributes).map(a => ({
+        text: a,
+        value: a
+      }));
+    },
+    getOperatorsForAttribute() {
+      return (orIndex, andIndex) => {
+        const predicate = this.getPredicate(orIndex, andIndex);
+        if (!predicate) {
+          return [];
+        }
+        const attributeFullPath = predicate.attribute;
+        if (!attributeFullPath) {
+          return [];
+        }
+        const attributeType = this.attributes[attributeFullPath]
+          ? this.attributes[attributeFullPath].type
+          : null;
+
+        if (!attributeType) {
+          return [];
+        }
+        return getOperatorsByFieldType(attributeType, this.lang);
+      };
+    },
+    getPredicate() {
+      return (orIndex, andIndex) => {
+        if (
+          !this.filter ||
+          !this.filter[orIndex] ||
+          !this.filter[orIndex][andIndex]
+        ) {
+          console.log(`Predicate not found for [${orIndex}, ${andIndex}]`);
+          return null;
+        }
+        return this.filter[orIndex][andIndex];
+      };
+    }
+  },
+  methods: {
+    onAttributeChange(orIndex, andIndex) {
+      const predicate = this.getPredicate(orIndex, andIndex);
+      if (!predicate) {
+        return;
+      }
+      predicate.operator = null;
+      this.$emit('input', this.filter);
+    },
+    addOrCondition() {
+      this.filter.push(emptyAdvancedFilter()[0]);
+    },
+    addAndCondition(orIndex) {
+      if (!this.filter[orIndex]) {
+        return false;
+      }
+      this.filter[orIndex].push(emptyAdvancedFilter()[0][0]);
+    },
+    removeAndCondition(orIndex, andIndex) {
+      if (!this.filter[orIndex] || !this.filter[orIndex][andIndex]) {
+        return false;
+      }
+      if (this.filter.length === 1 && this.filter[0].length === 1) {
+        this.$set(this.filter[0], 0, emptyAdvancedFilter());
+        this.$emit('input', this.filter);
+        return;
+      }
+      if (this.filter[orIndex].length === 1 && this.filter.length > 1) {
+        this.filter.splice(orIndex, 1);
+        this.$emit('input', this.filter);
+        return;
+      }
+      this.filter[orIndex].splice(andIndex, 1);
+      this.$emit('input', this.filter);
+    }
+  },
+  watch: {
+    value: {
+      immediate: true,
+      handler() {
+        this.filter = cloneDeep(this.value);
+      }
+    },
+    // Cannot trigger @input here, since it triggers an update loop (this watcher
+    // gets triggered every time the props change).
+    // We must trigger the @input event only after interactions with the DOM elements.
+    filter: {
+      immediate: false,
+      handler() {
+        this.$log.debug('Advanced filter has changed!');
+        // this.$log.debug(JSON.stringify(this.filter, null, 2));
+      }
+    }
+  }
+};
+</script>

--- a/src/services/FilterUtils.ts
+++ b/src/services/FilterUtils.ts
@@ -1,0 +1,310 @@
+import findKey from 'lodash/findKey';
+
+export const getOperatorsByFieldType = (
+  fieldType: string,
+  lang: 'koncorde' | 'es' = 'koncorde'
+) => {
+  // TODO complete this with geospatial operators
+  const range = {
+    text: 'is between',
+    value: 'range'
+  };
+  const dateRangeTs = {
+    text: 'is between timestamps',
+    value: 'date_range_ts'
+  };
+  const dateRange = {
+    text: 'is between dates',
+    value: 'date_range'
+  };
+  const exactMatch = {
+    text: 'matches exactly',
+    value: 'exact_match'
+  };
+  const fuzzyMatch = {
+    text: 'matches regex',
+    value: 'fuzzy_match'
+  };
+  const regexpMatch = {
+    text: 'matches regex',
+    value: 'regexp_match'
+  };
+  const exists = {
+    text: 'exists',
+    value: 'exists'
+  };
+  const missing = {
+    text: 'does not exist',
+    value: 'missing'
+  };
+  const isIn = {
+    text: 'is one of',
+    value: 'is_in'
+  };
+  const geoDistance = {
+    text: 'is within cercle',
+    value: 'geo_distance'
+  };
+  const unsupported = {
+    text: 'field type not supported',
+    value: 'unsupported'
+  };
+
+  switch (fieldType) {
+    case 'keyword':
+      return [exactMatch, regexpMatch, isIn, exists, missing];
+    case 'text':
+      return lang === 'koncorde'
+        ? [exactMatch, regexpMatch, isIn, exists, missing]
+        : [exactMatch, regexpMatch, fuzzyMatch, isIn, exists, missing];
+    case 'integer':
+    case 'long':
+    case 'double':
+    case 'float':
+      return [range, isIn, exists, missing];
+    case 'date':
+      return [dateRangeTs, dateRange, exists, missing];
+    case 'geo_point':
+      return [geoDistance];
+    default:
+      return [unsupported];
+  }
+};
+
+// KONCORDE
+///////////////////////////////////////////////////////////////////
+
+enum advancedFilterOperator {
+  'exact_match' = 'exact_match',
+  'is_in' = 'is_in',
+  'range' = 'range',
+  'exists' = 'exists',
+  'regexp_match' = 'regexp_match',
+  'missing' = 'missing',
+  'geo_distance' = 'geo_distance'
+}
+
+const koncordeToAdvancedFilterOperator = {
+  equals: advancedFilterOperator.exact_match,
+  in: advancedFilterOperator.is_in,
+  range: advancedFilterOperator.range,
+  exists: advancedFilterOperator.exists,
+  regexp: advancedFilterOperator.regexp_match,
+  geoDistance: advancedFilterOperator.geo_distance
+};
+
+export interface KoncordeRange {
+  range: {
+    [field: string]: {
+      gte?: Number;
+      lte?: Number;
+      gt?: Number;
+      lt?: Number;
+    };
+  };
+}
+
+export interface KoncordeEquals {
+  equals: {
+    [field: string]: string;
+  };
+}
+
+export interface KoncordeRegexp {
+  regexp: {
+    [field: string]: {
+      value: string;
+      flags: string;
+    };
+  };
+}
+
+export interface KoncordeIn {
+  in: {
+    [field: string]: string[];
+  };
+}
+
+export type KoncordeClause =
+  | KoncordeRange
+  | KoncordeEquals
+  | KoncordeRegexp
+  | KoncordeIn;
+export interface KoncordeAndGroup {
+  and: KoncordeClause[];
+}
+export interface StandardKoncordeFilter {
+  or: KoncordeAndGroup[];
+}
+
+export interface AdvancedFilterPredicate {
+  attribute: string | null;
+  operator: // TODO complete this with ES-compliant operators
+  advancedFilterOperator | null;
+  value?: any | null;
+}
+export type AdvancedFilter = AdvancedFilterPredicate[][];
+
+export const emptyAdvancedFilter = (): AdvancedFilter => [
+  [{ attribute: null, operator: null, value: null }]
+];
+
+// TODO - Test all the if statements in this function
+/**
+ * Transforms a Koncorde filter into the Advanced Filter UI Schema.
+ * The Koncorde filter must be in the [boolean form]
+ * (https://docs.kuzzle.io/core/2/api/koncorde-filters-syntax/operators/#bool)
+ * and comply to the following pattern
+ * ```
+ *  {
+ *    or: [
+ *     {
+ *       and: [
+ *         ...predicates...
+ *       ]
+ *     },
+ *     {
+ *       and: [
+ *         ...predicates...
+ *       ]
+ *     },
+ *    ]
+ *  }
+ * ```
+ *
+ * @param filter
+ */
+export const koncordeFilterToAdvancedFilter = (
+  filter: StandardKoncordeFilter
+): AdvancedFilter => {
+  if (!filter.or) {
+    throw new Error(
+      'The Koncorde filter does not comply with the expected shape: root `or` not found.'
+    );
+  }
+  if (filter.or.length === 0) {
+    // TODO test this
+    return emptyAdvancedFilter();
+  }
+  return filter.or.map((andGroup: KoncordeAndGroup) => {
+    if (!andGroup.and) {
+      throw new Error(
+        'The Koncorde filter does not comply with the expected shape: `and` not found in `or` group.'
+      );
+    }
+    if (andGroup.and.length === 0) {
+      // TODO test this
+      return emptyAdvancedFilter()[0];
+    }
+    return andGroup.and.map((clause: KoncordeClause) =>
+      koncordeClauseToAdvancedFilterPredicate(clause)
+    );
+  });
+};
+
+function koncordeClauseToAdvancedFilterPredicate(
+  clause: KoncordeClause
+): AdvancedFilterPredicate {
+  const koncordeOperator = Object.keys(clause)[0];
+  // TODO complete this
+  if (
+    koncordeOperator === 'equals' ||
+    koncordeOperator === 'in' ||
+    koncordeOperator === 'range' ||
+    koncordeOperator === 'regexp'
+  ) {
+    const operatorValues = clause[koncordeOperator as keyof typeof clause];
+    if (!operatorValues) {
+      throw new Error(
+        `Unable to translate Koncorde Clause ${JSON.stringify(clause)}`
+      );
+    }
+    const attribute = Object.keys(operatorValues)[0];
+    return {
+      attribute,
+      operator: koncordeToAdvancedFilterOperator[koncordeOperator],
+      value: operatorValues[attribute]
+    };
+  }
+
+  throw new Error(
+    `Unable to translate Koncorde Clause ${JSON.stringify(clause)}`
+  );
+}
+
+// export const advancedFilterToKoncordeFilter = (
+//   advFilter: AdvancedFilterPredicate[][]
+// ): StandardKoncordeFilter | null => {
+//   const koncordeFilter: StandardKoncordeFilter = {
+//     or: []
+//   };
+//   if (!Array.isArray(advFilter)) {
+//     throw new Error('Malformed AdvancedFilter - not an array');
+//   }
+
+//   // Filter out the empty predicates
+//   let cleanFilter = advFilter
+//     .map(orBlock =>
+//       orBlock.filter(
+//         predicate =>
+//           !!predicate.attribute && !!predicate.operator && !!predicate.value
+//       )
+//     )
+//     .filter(orBlock => orBlock.length > 0); // Filter out the empty or-blocks
+
+//   if (cleanFilter.length === 0) {
+//     return null;
+//   }
+
+//   koncordeFilter.or = cleanFilter.map(orBlock => ({
+//     and: orBlock.map(advancedFilterPredicateToKoncordeClause)
+//   }));
+//   return koncordeFilter;
+// };
+
+/**
+ * Translates this
+ * {
+ *  attribute: 'toto',
+ *  operator: 'equals',
+ *  value: 'titi'
+ * }
+ * to this
+ * {
+ *  equals: {
+ *   toto: 'titi'
+ *  }
+ * }
+ * @param predicate The AdvancedFilter predicate to translate
+ */
+// function advancedFilterPredicateToKoncordeClause(
+//   predicate: AdvancedFilterPredicate
+// ): KoncordeClause {
+//   if (!predicate.operator) {
+//     throw new Error('Invalid predicate: null operator.');
+//   }
+//   if (!predicate.attribute) {
+//     throw new Error('Invalid predicate: null attribute.');
+//   }
+//   const operator = findKey(
+//     koncordeToAdvancedFilterOperator,
+//     v => v === predicate.operator
+//   );
+
+//   if (!operator) {
+//     throw new Error(
+//       `Invalid predicate: unknown operator ${predicate.operator}`
+//     );
+//   }
+
+//   return {
+//     [operator]: {
+//       [predicate.attribute]: predicate.value
+//     }
+//   };
+// }
+
+// ELASTICSEARCH
+///////////////////////////////////////////////////////////////////
+
+// TODO


### PR DESCRIPTION
Introducing the Advanced Filter in the shared components. It is directly inspired by the one we're using on the Admin Console but rather improved, with conditional operators (based on the field type) and implemented Koncorde filter utilities.

⚠️ This component is incomplete and hardly usable. Here is what is missing

- [ ] utility service to translate Elasticsearch queries to Advanced Filter objects
- [ ] searchable field dropdown selector (for collections with huge mappings)
- [ ] splitting input widgets in different components and refactor logic inside them (e.g. range input for `range` operators, pill-list for `in` operators, date-pickers, etc...)
- [ ] improve the filter translation services in order to avoid to wrap the generated queries into useless `and` and `or` operators, when possible
- [ ] more stuff I don't remember about right now, sorry
